### PR TITLE
Migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-dep-scripts=true

--- a/package.json
+++ b/package.json
@@ -50,10 +50,5 @@
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.9.5"
   },
-  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
-  "pnpm": {
-    "overrides": {
-      "form-data@4": "^4.0.4"
-    }
-  }
+  "packageManager": "pnpm@11.1.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: false
+overrides:
+  form-data@4: ^4.0.4


### PR DESCRIPTION
This PR migrates the repo from pnpm v10 to v11.

### What changed

- Ran the [`pnpm-v10-to-v11`](https://app.codemod.com/registry/pnpm-v10-to-v11) codemod, which moves pnpm config out of `package.json`/`.npmrc` and into `pnpm-workspace.yaml`, and bumps the `packageManager` field.
- Forced every entry under `allowBuilds` in `pnpm-workspace.yaml` to `false`. pnpm v11 no longer runs dependency build scripts by default; we're opting out across the board rather than carrying over the previous allow-list. If a package legitimately needs its build scripts to run, flip its entry back to `true` in a follow-up.
- Re-ran `pnpm install` so the lockfile reflects the new config.


Created with ❤️ using [wayflyer/repos](https://github.com/wayflyer/repos)! 💪