### PR TITLE
Updates to use Cloudsmith for NPM

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ allowBuilds:
   esbuild: false
 overrides:
   form-data@4: ^4.0.4
+# TODO: Remove temporary per-repo registry config for the Cloudsmith migration.
+minimumReleaseAge: 0
+registries:
+  default: "https://npm.wayflyer.net/wayflyer/"


### PR DESCRIPTION
Updates this repo to use Cloudsmith for NPM.

Because lockfile changes are required, I've added in temporary config to `pnpm-workspace.yaml` pointing this repo at Cloudsmith.

This also disables the global devcontainer `minimumReleaseAge` config, since Cloudsmith release ages represent when the package was uploaded/cached rather than the upstream release age. We also have equivalent config provided in the Cloudsmith firewall, so this can be removed completely from the global devcontainer config once we're fully migrated.

## Migration plan 🏗️

1. Update all repos to use Cloudsmith.
2. Ask people to merge in `main`, and give them a few days to do so.
3. Flip the global devcontainer config to Cloudsmith.
4. Remove the temporary config from `pnpm-workspace.yaml` in all repos.

Created with ❤️ using [wayflyer/repos](https://github.com/wayflyer/repos)! 💪