### PR TITLE
Remove Cloudsmith integration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,3 @@ allowBuilds:
   esbuild: false
 overrides:
   form-data@4: ^4.0.4
-# TODO: Remove temporary per-repo registry config for the Cloudsmith migration.
-minimumReleaseAge: 0
-registries:
-  default: "https://npm.wayflyer.net/wayflyer/"


### PR DESCRIPTION
We're sticking with AWS CodeArtifact.

Created with ❤️ using [wayflyer/repos](https://github.com/wayflyer/repos)! 💪